### PR TITLE
updates request for current BTC/USD rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+config.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ The program takes user input for a date and an amount in USD, and returns the di
 bitcoin then and yesterday. Rates use volume-weighted average price (VWAP), and values are rounded to two decimals in
 instances when a human would expect it.
 
-It uses Bitstamp data from the free [Quandl API](https://www.quandl.com/data/BITSTAMP-Bitstamp).
+It uses Bitstamp data from the free [Quandl API](https://www.quandl.com/data/BITSTAMP-Bitstamp). To use it, add your API key
+somewhere as: `authtoken = YOUR_API_KEY`
+
+This can be in a separate config.py file, or at the top of btcince.py or transactions.py.
 
 ## errata
 My first stab at this was with the [btcince.py](btcince/btcince.py) script, which is one big quick sketch of a function. The

--- a/transactions.py
+++ b/transactions.py
@@ -2,11 +2,15 @@
 
 """The point of this module is to compare an old value in Bitcoin to now.
 
-As a script, it takes user input for a date and an amount in USD, and returns
-difference in value between that amount in bitcoin then and yesterday.
-Rates use volume-weighted average price (VWAP), and values are rounded to two
-decimals in instances when a human would expect it. It uses Bitstamp data
-from the free Quandl API.
+Given a date and an amount in USD, it returns the difference in value between
+that amount in bitcoin then and yesterday. Rates use volume-weighted average
+price (VWAP), and values are rounded to two decimals in instances when a
+human would expect it.
+
+It uses Bitstamp data from the free Quandl API. To use it, add your API key
+somewhere as:
+
+authtoken = YOUR_API_KEY
 """
 
 from config import authtoken
@@ -65,6 +69,7 @@ class Transaction(object):
         """Get yesterday's BTC/USD rate."""
         yesterday = (datetime.date.today() - datetime.timedelta(days=1))\
             .isoformat()
+            if yesterday 
         yesterday_rates = quandl.get('BITSTAMP/USD', authtoken=authtoken,\
             start_date=yesterday, end_date=yesterday)
         yesterday_vwap = yesterday_rates['VWAP'][0]

--- a/transactions.py
+++ b/transactions.py
@@ -104,7 +104,7 @@ class Transaction(object):
         diff = anon.calculate_latest_value_difference(new_value_nice)
 
         print(f'You started with USD {anon.orig_usd} on {anon.orig_date}, which equaled BTC {anon.orig_btc}')
-        print(f'As of now, that amount of bitcoin was valued at ${new_value_nice}.\n')
+        print(f'As of now, that amount of bitcoin is valued at ${new_value_nice}.\n')
         print(f'The change in value is ${round(diff, 2)}.')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes issue #2 

There was a bug when getting current time and finding the exchange rate for the previous day. By using naive datetime object, users in a timezone well ahead of New York's could get an empty row, resulting in an IndexError when the logic calls for data in the corresponding 'VWAP' column.

For example, a user in UTC+8 running the program November 9 at 6am would be polling the API at November 8 at 6pm in NYC. Subtracting a day from the user's current datetime would result in a request for the exchange rate on November 8, yet at this point, the API has not yet posted that data.

